### PR TITLE
Prevent cancellation error in FireFox if end-of-stream has been r…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,9 @@ export async function fetchFromUrl(audioTrackUrl: string, options?: IOptions): P
     if (response.body) {
       const res = await this.parseReadableStream(response.body, contentType, options);
       debug('Closing HTTP-readable-stream...');
-      await response.body.cancel();
+      if (!response.body.locked) { // Prevent error in Firefox
+        await response.body.cancel();
+      }
       debug('HTTP-readable-stream closed.');
       return res;
     } else {


### PR DESCRIPTION
It looks like if the End-Of-Stream has been reached, Firefox puts it it a locked state (normally used if a read is pending), or maybe it fails to unlock the stream of an End-Of-Stream is thrown.

Anyway, is a workaround to the issue.

Should solve #26: fetchFromURL can't get metadata from m4a file