### PR TITLE
Pass name Blob.name via options.path

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -43,3 +43,6 @@ update_configs:
           dependency_name: "ts-loader"
       - match:
           dependency_name: "webpack"
+      - match:
+          dependency_name: "es-lint"
+

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -24,4 +24,19 @@ update_configs:
           dependency_name: "coveralls"
       - match:
           dependency_name: "nyc"
-
+      - match:
+          dependency_name: "karma-coverage-istanbul-reporter"
+          update_type: "semver:minor"
+      - match:
+          dependency_name: "karma-jasmine"
+          update_type: "semver:minor"
+      - match:
+          dependency_name: "karma-spec-reporter"
+          update_type: "semver:minor"
+      - match:
+          dependency_name: "karma-webpack"
+          update_type: "semver:minor"
+      - match:
+          dependency_name: "ts-loader"
+      - match:
+          dependency_name: "webpack"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,6 +8,9 @@ update_configs:
           dependency_name: "@types/node"
           update_type: "semver:minor"
       - match:
+          dependency_name: "@types/jasmine"
+          update_type: "semver:minor"
+      - match:
           dependency_name: "music-metadata"
           update_type: "semver:minor"
       - match:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -51,6 +51,11 @@ export const parseBuffer = mm.parseBuffer;
  */
 export function parseBlob(blob: Blob, options?: IOptions): Promise<IAudioMetadata> {
   return convertBlobToBuffer(blob).then(buf => {
+    if ((blob as File).name) {
+      options = options ? options : {};
+      options.path = (blob as File).name; // Store name as possible type fallback
+      debug('options.path', options.path);
+    }
     return mm.parseBuffer(buf, blob.type, options);
   });
 }


### PR DESCRIPTION
Pass name `Blob.name` via `options.path`.

Fixing: [audio-tag-analyzer#113](https://github.com/Borewit/audio-tag-analyzer/issues/113)
Depending on: [music-metadata#335](https://github.com/Borewit/music-metadata/pull/335)