### PR TITLE
Abstraction from `Buffer` to `Uint8Array`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,9 +1,7 @@
-import { Buffer } from 'buffer';
 import * as initDebug from 'debug';
 import { IAudioMetadata, IOptions } from 'music-metadata/lib/type';
 import * as mm from 'music-metadata/lib/core';
 import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
-import * as toBuffer from 'typedarray-to-buffer';
 
 const debug = initDebug('music-metadata-browser:main');
 
@@ -41,12 +39,12 @@ export async function parseReadableStream(stream: ReadableStream, fileInfo?: mm.
  * @returns Metadata
  */
 export async function parseBlob(blob: Blob, options?: IOptions): Promise<IAudioMetadata> {
-  const buf = await convertBlobToBuffer(blob);
+  const uint8Array = await convertBlobToUint8Array(blob);
   const fileInfo: mm.IFileInfo = {mimeType: blob.type, size: blob.size};
   if ((blob as File).name) {
     fileInfo.path = (blob as File).name;
   }
-  return mm.parseBuffer(buf, {mimeType: blob.type, size: blob.size}, options);
+  return mm.parseBuffer(uint8Array, {mimeType: blob.type, size: blob.size}, options);
 }
 
 /**
@@ -82,16 +80,15 @@ export async function fetchFromUrl(audioTrackUrl: string, options?: IOptions): P
 /**
  * Convert Web API File to Node Buffer
  * @param blob - Web API Blob
- * @returns Metadata
+ * @returns Uint8Array
  */
-function convertBlobToBuffer(blob: Blob): Promise<Buffer> {
-  return new Promise<Buffer>((resolve, reject) => {
-
+function convertBlobToUint8Array(blob: Blob): Promise<Uint8Array> {
+  return new Promise<Uint8Array>((resolve, reject) => {
     const fileReader = new FileReader();
     fileReader.onloadend = event => {
       let data = (event.target as any).result;
       if (data instanceof ArrayBuffer) {
-        data = toBuffer(new Uint8Array((event.target as any).result));
+        data = new Uint8Array(data);
       }
       resolve(data);
     };

--- a/package.json
+++ b/package.json
@@ -115,9 +115,8 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "debug": "^4.3.2",
-    "music-metadata": "^7.10.0",
+    "music-metadata": "^7.11.0",
     "readable-stream": "^3.6.0",
-    "readable-web-to-node-stream": "^3.0.2",
-    "typedarray-to-buffer": "^4.0.0"
+    "readable-web-to-node-stream": "^3.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -144,7 +144,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*":
+"@types/node@*", "@types/node@^16.4.1":
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.1.tgz#9fad171a5b701613ee8a6f4ece3c88b1034b1b03"
   integrity sha512-UW7cbLqf/Wu5XH2RKKY1cHwUNLicIDRLMraYKz+HHAerJ0ZffUEk+fMnd8qU2JaS6cAy0r8tsaf7yqHASf/Y0Q==
@@ -153,11 +153,6 @@
   version "14.14.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
-
-"@types/node@^16.4.1":
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.1.tgz#9fad171a5b701613ee8a6f4ece3c88b1034b1b03"
-  integrity sha512-UW7cbLqf/Wu5XH2RKKY1cHwUNLicIDRLMraYKz+HHAerJ0ZffUEk+fMnd8qU2JaS6cAy0r8tsaf7yqHASf/Y0Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -754,7 +749,6 @@ cliui@^7.0.2:
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
-  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
   dependencies:
     is-plain-object "^2.0.4"
     kind-of "^6.0.2"
@@ -1834,7 +1828,6 @@ is-plain-obj@^1.1.0:
 is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
-  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
 
@@ -1886,7 +1879,6 @@ isexe@^2.0.0:
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2145,7 +2137,11 @@ karma@^6.3.4:
     ua-parser-js "^0.7.28"
     yargs "^16.1.1"
 
-kind-of@^6.0.2, kind-of@^6.0.3:
+kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
+kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -2433,10 +2429,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-music-metadata@^7.10.0:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/music-metadata/-/music-metadata-7.10.0.tgz#bf49c6e4a7e86f89ab5260c211bd47a1d4fb225f"
-  integrity sha512-Yw5yNnL9WKq/q0ygOcrCkCH93/0JGlDfeIIvkv8F7ZB1ww6Z5mtEj3cwTc+tObhu/CyCIIRIADA5fRy0HsDu6Q==
+music-metadata@^7.11.0:
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/music-metadata/-/music-metadata-7.11.0.tgz#86fd06e42955b31cda4eb785fc7fed405e9d7a17"
+  integrity sha512-mDS6tZt0csbKCpWJcUlyjv5OIYUHnDDLm7phwRmVT/2jSPxHjvwZwUOx2/dD+uH5n2XGTB0iAqWNtmZJO4L3Hw==
   dependencies:
     content-type "^1.0.4"
     debug "^4.3.2"
@@ -2579,7 +2575,6 @@ p-map@^4.0.0:
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
-  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -2681,7 +2676,6 @@ process-nextick-args@~2.0.0:
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 progress@^2.0.0:
   version "2.0.3"
@@ -2705,7 +2699,6 @@ psl@^1.1.28:
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
@@ -2731,7 +2724,6 @@ qs@~6.5.2:
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 quick-lru@^5.1.1:
   version "5.1.1"
@@ -3010,7 +3002,6 @@ setprototypeof@1.1.1:
 shallow-clone@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
-  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
 
@@ -3108,6 +3099,7 @@ source-map@^0.6.0, source-map@^0.6.1:
 source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -3479,11 +3471,6 @@ typedarray-to-buffer@^3.0.4:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedarray-to-buffer@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz#cdd2933c61dd3f5f02eda5d012d441f95bfeb50a"
-  integrity sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==
-
 typescript@^4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
@@ -3511,7 +3498,6 @@ uri-js@^4.2.2:
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
-  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"


### PR DESCRIPTION
Update music-metadata from [7.10.0](https://github.com/Borewit/music-metadata/releases/tag/v7.10.0) to [7.11.0](https://github.com/Borewit/music-metadata/releases/tag/v7.11.0).
Get rid of dependency `typedarray-to-buffer`.