### PR TITLE
Shim `blob.stream()` for Safari < 14.1

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -54,6 +54,14 @@ const parsers: IParserTest[] = [
     }
   },
   {
+    methodDescription: 'parseBlob() without blob.stream being implemented',
+    parseUrl: async (audioTrackUrl, options) => {
+      const blob = await getAsBlob(audioTrackUrl);
+      blob.stream = undefined; // Simulate `stream()` not being implemented by browser (e.g. Safari < 14.1)
+      return mm.parseBlob(blob, options);
+    }
+  },
+  {
     methodDescription: 'fetchFromUrl()',
     parseUrl: (audioTrackUrl, options) => {
       return mm.fetchFromUrl(audioTrackUrl, options);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -43,9 +43,43 @@ export async function parseBlob(blob: Blob, options?: IOptions): Promise<IAudioM
   if (blob instanceof File) {
     fileInfo.path = (blob as File).name;
   }
-  return parseReadableStream(blob.stream(), {mimeType: blob.type, size: blob.size}, options);
+
+  const stream = blob.stream ? blob.stream() : convertBlobToReadableStream(blob);
+  return parseReadableStream(stream, {mimeType: blob.type, size: blob.size}, options);
 }
 
+/**
+ * Convert Blob to ReadableStream
+ * Fallback for Safari versions < 14.1
+ * @param blob
+ */
+function convertBlobToReadableStream(blob: Blob): ReadableStream {
+
+  const fileReader = new FileReader();
+
+  return new ReadableStream({
+    start(controller) {
+      // The following function handles each data chunk
+      fileReader.onloadend = event => {
+        let data = (event.target as any).result;
+        if (data instanceof ArrayBuffer) {
+          data = new Uint8Array(data);
+        }
+        controller.enqueue(data);
+        controller.close();
+      };
+
+      fileReader.onerror = error => {
+        controller.close();
+      };
+
+      fileReader.onabort = error => {
+        controller.close();
+      };
+      fileReader.readAsArrayBuffer(blob);
+    }
+  });
+}
 /**
  * Parse fetched file, using the Web Fetch API
  * @param audioTrackUrl - URL to download the audio track from


### PR DESCRIPTION
Allow `parseBlob()` to be used with older versions (<14.1) of Safari.

Resolves Borewit/music-metadata-browser#624